### PR TITLE
Double click to select/deselect all

### DIFF
--- a/js/jscut.js
+++ b/js/jscut.js
@@ -233,7 +233,7 @@ function loadSvg(alert, filename, content) {
     if(alert)
         alert.remove();
     showAlert("loaded " + filename, "alert-success");
-    tutorial(2, 'Click 1 or more objects.');
+    tutorial(2, 'Click 1 or more objects or double click to select all');
 }
 
 $(document).on('change', '#choose-svg-file', function (event) {
@@ -275,9 +275,33 @@ function openSvgDropbox() {
 }
 
 $("#MainSvg").click(function (e) {
+    // Ignore double click
+    if (e.originalEvent.detail > 1)
+        return;
+
     var element = Snap.getElementByPoint(e.pageX, e.pageY);
     if (element != null) {
         operationsViewModel.clickOnSvg(element) || tabsViewModel.clickOnSvg(element) || selectionViewModel.clickOnSvg(element);
+        if (selectionViewModel.selNumSelected() > 0) {
+            tutorial(3, 'Click "Create Operation" after you have finished selecting objects.');
+        }
+    }
+});
+
+$("#MainSvg").dblclick(function (e) {
+    // Toggle select all
+    if (selectionViewModel.selNumSelected() > 1) {
+        selectionViewModel.clearSelection();
+        return;
+    }
+
+    var selectedPaths = mainSvg.selectAll('path');
+    if (selectedPaths.length > 0) {
+        selectedPaths.forEach(function (element) {
+            if (element.attr("class") != "selectedPath") {
+                operationsViewModel.clickOnSvg(element) || tabsViewModel.clickOnSvg(element) || selectionViewModel.clickOnSvg(element);
+            }
+        });
         if (selectionViewModel.selNumSelected() > 0) {
             tutorial(3, 'Click "Create Operation" after you have finished selecting objects.');
         }


### PR DESCRIPTION
As the title suggests, allows selecting all paths by double clicking. Double clicking again will deselect all paths.

I was thinking about a warning if there was an active selection or ability to undo, in case double click is accidental. Or this can be easily tied to a "Select All" button instead.

Also, regarding https://github.com/tbfleming/jscut/issues/19 , it should be about 5 more lines of code to select all of the same color objects in the document if you double click on a path instead of an empty area. If that sounds useful I can whip it up quickly.