### PR TITLE
Add Rapid Z setting

### DIFF
--- a/js/Cam.js
+++ b/js/Cam.js
@@ -372,7 +372,8 @@ jscut.priv.cam = jscut.priv.cam || {};
 
         var retractGcode =
             '; Retract\r\n' +
-            'G1 Z' + safeZ.toFixed(decimal) + rapidFeedGcode + '\r\n';
+            'G1 Z' + safeZ.toFixed(decimal) + retractFeedGcode + '\r\n';
+
 
         var retractForTabGcode =
             '; Retract for tab\r\n' +
@@ -420,7 +421,7 @@ jscut.priv.cam = jscut.priv.cam || {};
                 gcode +=
                     '; Rapid to initial position\r\n' +
                     'G1' + convertPoint(origPath[0], false) + rapidFeedGcode + '\r\n' +
-                    'G1 Z' + currentZ.toFixed(decimal) + '\r\n';
+                    'G1 Z' + currentZ.toFixed(decimal) + retractFeedGcode + '\r\n';
 
                 var selectedPaths;
                 if (nextZ >= tabZ || useZ)

--- a/js/GcodeConversionViewModel.js
+++ b/js/GcodeConversionViewModel.js
@@ -82,6 +82,7 @@ function GcodeConversionViewModel(options, miscViewModel, materialViewModel, too
         var safeZ = self.unitConverter.fromInch(materialViewModel.matZSafeMove.toInch());
         var rapidRate = self.unitConverter.fromInch(toolModel.rapidRate.toInch());
         var plungeRate = self.unitConverter.fromInch(toolModel.plungeRate.toInch());
+        var rapidZRate = self.unitConverter.fromInch(toolModel.rapidZRate.toInch());
         var cutRate = self.unitConverter.fromInch(toolModel.cutRate.toInch());
         var passDepth = self.unitConverter.fromInch(toolModel.passDepth.toInch());
         var topZ = self.unitConverter.fromInch(materialViewModel.matTopZ.toInch());
@@ -115,7 +116,7 @@ function GcodeConversionViewModel(options, miscViewModel, materialViewModel, too
         else
             gcode += "G21         ; Set units to mm\r\n";
         gcode += "G90         ; Absolute positioning\r\n";
-        gcode += "G1 Z" + safeZ + " F" + rapidRate + "      ; Move to clearance level\r\n"
+        gcode += "G1 Z" + safeZ + " F" + rapidZRate + "      ; Move to clearance level\r\n"
 
         for (var opIndex = 0; opIndex < ops.length; ++opIndex) {
             var op = ops[opIndex];
@@ -135,6 +136,7 @@ function GcodeConversionViewModel(options, miscViewModel, materialViewModel, too
                 "\r\n; Cut Depth:    " + cutDepth +
                 "\r\n; Pass Depth:   " + passDepth +
                 "\r\n; Plunge rate:  " + plungeRate +
+                "\r\n; Rapid Z rate:  " + rapidZRate +
                 "\r\n; Cut rate:     " + cutRate +
                 "\r\n;\r\n";
 
@@ -151,7 +153,7 @@ function GcodeConversionViewModel(options, miscViewModel, materialViewModel, too
                 safeZ:          safeZ,
                 passDepth:      passDepth,
                 plungeFeed:     plungeRate,
-                retractFeed:    rapidRate,
+		retractFeed:    rapidZRate,
                 cutFeed:        cutRate,
                 rapidFeed:      rapidRate,
                 tabGeometry:    tabGeometry,

--- a/js/OperationsViewModel.js
+++ b/js/OperationsViewModel.js
@@ -25,12 +25,14 @@ function ToolModel() {
     self.stepover = ko.observable(.4);
     self.rapidRate = ko.observable(100);
     self.plungeRate = ko.observable(5);
+    self.rapidZRate = ko.observable(10);
     self.cutRate = ko.observable(40);
 
     self.unitConverter.add(self.diameter);
     self.unitConverter.add(self.passDepth);
     self.unitConverter.add(self.rapidRate);
     self.unitConverter.add(self.plungeRate);
+    self.unitConverter.add(self.rapidZRate);
     self.unitConverter.add(self.cutRate);
 
     self.angle.subscribe(function (newValue) {
@@ -68,6 +70,7 @@ function ToolModel() {
             'stepover': self.stepover(),
             'rapidRate': self.rapidRate(),
             'plungeRate': self.plungeRate(),
+            'rapidZRate': self.rapidZRate(),
             'cutRate': self.cutRate(),
         };
     }
@@ -88,6 +91,7 @@ function ToolModel() {
             f(json.stepover, self.stepover);
             f(json.rapidRate, self.rapidRate);
             f(json.plungeRate, self.plungeRate);
+            f(json.rapidZRate, self.rapidZRate);
             f(json.cutRate, self.cutRate);
         }
     }

--- a/jscut.html
+++ b/jscut.html
@@ -370,6 +370,10 @@ along with jscut.  If not, see <http://www.gnu.org/licenses/>.
                                     <td><span data-bind="text: units"></span>/min
                                     <td><input id="toolPlungeRate" type="number" step="any" data-bind="value: plungeRate">
                                 <tr>
+                                    <td><label for="toolRapidZRRate" class="control-label">Rapid Z</label>
+                                    <td><span data-bind="text: units"></span>/min
+                                    <td><input id="toolRapidZRate" type="number" step="any" data-bind="value: rapidZRate">
+                                <tr>
                                     <td><label for="toolCutRate" class="control-label">Cut</label>
                                     <td><span data-bind="text: units"></span>/min
                                     <td><input id="toolCutRate" type="number" step="any" data-bind="value: cutRate">


### PR DESCRIPTION
I found that the retraction speed was too fast for my z-axis. (old shapeko).  The problem is that the original code used the 'rapid' setting for **retraction**.  The default rate of 100 was too fast for my poor CNC.  It missed steps and didn't get to the clearance height and screwed up the job (chewing up lots of wood along the way)

I initially thought that I could use the **plunge** rate for retraction, and that would work.  But it seems like we need another knob here that is analogous to the 'rapid' setting, but just for the Z axis.  This would be used when ever we move in the Z direction while not **cutting**.  The two scenarios are retractions, and initial movement to the origin.

The initial rapid-Z is set to double of the default plunge rate. (Maybe there's a better option?)
