### PR TITLE
Selecting all available paths in svg

### DIFF
--- a/js/jscut.js
+++ b/js/jscut.js
@@ -284,6 +284,19 @@ $("#MainSvg").click(function (e) {
     }
 });
 
+$("#MainSvg").dblclick(function (e) {
+    var elements = Snap.selectAll("path");
+    for (let index = 0; index < elements.length; index++) {
+        var element = elements[index];
+        if (element != null) {
+            operationsViewModel.clickOnSvg(element) || tabsViewModel.clickOnSvg(element) || selectionViewModel.clickOnSvg(element);
+            if (selectionViewModel.selNumSelected() > 0) {
+                tutorial(3, 'Click "Create Operation" after you have finished selecting objects.');
+            }
+        }
+    }
+});
+
 function makeAllSameUnit(val) {
     "use strict";
     materialViewModel.matUnits(val);


### PR DESCRIPTION
Hi, first of all thanks for the great software! I just have one small suggestion. It would be great if there was an option to select all available paths in the document. If someone has a very fragmented svg, it's a pain to pick paths one by one. This is a quick & dirty fix just for me, but if this behavior is added to some UI buttons, it might be a useful little helper for many.